### PR TITLE
fix: disable unneeded services on live

### DIFF
--- a/community/sway/Packages-Desktop
+++ b/community/sway/Packages-Desktop
@@ -88,7 +88,7 @@ manjaro-hotfixes
 pamac-gtk
 
 # extra
-apparmor
+>extra apparmor
 >extra xdg-user-dirs
 >extra manjaro-printer
 >extra atool

--- a/community/sway/profile.conf
+++ b/community/sway/profile.conf
@@ -34,7 +34,7 @@ geoip="true"
 
 # unset defaults to given values
 # names must match systemd service names
-enable_systemd=('avahi-daemon' 'bluetooth' 'ModemManager' 'NetworkManager' 'org.cups.cupsd' 'tlp' 'tlp-sleep' 'haveged' 'ufw' 'apparmor' 'snapd.apparmor' 'snapd' 'greetd')
+enable_systemd=('apparmor' 'avahi-daemon' 'bluetooth' 'cups' 'fstrim.timer' 'greetd' 'haveged' 'ModemManager' 'NetworkManager' 'pkgfile–update.timer' 'tlp' 'tlp-sleep' 'snapd' 'snapd.apparmor' 'ufw')
 # disable_systemd=('pacman-init')
 
 # add strict snaps: strict_snaps="core core18 gnome-3-28-1804 gtk-common-themes snap-store"
@@ -78,3 +78,4 @@ login_shell=/bin/zsh
 # names must match systemd service names
 # services in enable_systemd array don't need to be listed here
 # enable_systemd_live=('manjaro-live' 'mhwd-live' 'pacman-init' 'mirrors-live')
+disable_systemd_live=('apparmor' 'avahi-daemon' 'cups' 'fstrim.timer' 'pkgfile–update.timer' 'snapd' 'snapd.apparmor' 'tlp' 'tlp-sleep' 'ufw')


### PR DESCRIPTION
closes https://github.com/Manjaro-Sway/manjaro-sway/issues/57

aligning the `enable_systemd` and the `disable_systemd_live` (that isn't documented wtf) with the official gnome profile and sorting alphabetically for easier comparison