### PR TITLE
chore: remove kitty

### DIFF
--- a/community/sway/Packages-Desktop
+++ b/community/sway/Packages-Desktop
@@ -7,7 +7,6 @@ manjaro-sway/manjaro-sway-settings
 >extra wlsunset # time & place based light temperature
 >extra kanshi # automatically load matching output profiles
 >extra autotiling # automated tiling
->extra kitty # advanced terminal application
 >extra manjaro-sway/nerd-fonts-roboto-mono # default terminal font
 
 # Wayland support


### PR DESCRIPTION
kitty is soon a non-optional dependency for manjaro-sway-settings, so its not needed here anymore.