### PR TITLE
fix: avoid iterating over libseat backends

### DIFF
--- a/community/sway/desktop-overlay/etc/environment
+++ b/community/sway/desktop-overlay/etc/environment
@@ -5,3 +5,5 @@
 #
 XDG_SESSION_TYPE=wayland
 XDG_CURRENT_DESKTOP=sway
+# avoid iterating over all libseat backends
+LIBSEAT_BACKEND=logind


### PR DESCRIPTION
libseat searches for a suitable backend and shows an unsettling warning
for the ones it doesn not find. this directly points it to the correct
backend for our setup.

closes https://github.com/Manjaro-Sway/manjaro-sway/issues/113