### PR TITLE
feat: add sensible default font for asian glyphs

### DIFF
--- a/community/sway/Packages-Desktop
+++ b/community/sway/Packages-Desktop
@@ -85,7 +85,6 @@ pamac-gtk
 >extra manjaro-settings-manager
 
 # extra fonts
->extra font-manager
 >extra wqy-microhei
 
 # CLI tools

--- a/community/sway/Packages-Desktop
+++ b/community/sway/Packages-Desktop
@@ -84,6 +84,10 @@ pamac-gtk
 >extra manjaro-printer
 >extra manjaro-settings-manager
 
+# extra fonts
+>extra font-manager
+>extra wqy-microhei
+
 # CLI tools
 neovim
 curl


### PR DESCRIPTION
closes https://github.com/Manjaro-Sway/manjaro-sway/issues/168

without the microhei font, pages like [this](https://en.wikipedia.org/wiki/Japanese_writing_system) were.. useless.

font-manager is 10MiB
wqy-microhei 5MiB

I have no strict opinion on the font-manager, it seems to be the smallest one in the repos though.