### PR TITLE
feat: add support for appimage, snap and flatpak

### DIFF
--- a/community/sway/Packages-Desktop
+++ b/community/sway/Packages-Desktop
@@ -79,6 +79,9 @@ manjaro-hotfixes
 >extra yay
 >extra manjaro-aur-support
 pamac-gtk
+>extra appimagelauncher
+>extra libpamac-snap-plugin
+>extra libpamac-flatpak-plugin
 
 # extra
 >extra apparmor


### PR DESCRIPTION
relates to https://github.com/Manjaro-Sway/manjaro-sway/discussions/215

this only enables the two toggles in pamac:
![image](https://user-images.githubusercontent.com/4662748/148555865-4e715ecf-34d3-47bc-8667-ffd51ee8ce03.png)

and a default handler for AppImages:
![image](https://user-images.githubusercontent.com/4662748/148555992-38378621-2f83-4a14-b063-cc318a2cdb5f.png)
![image](https://user-images.githubusercontent.com/4662748/148556299-a4f9f534-1b99-4293-872f-f2bb169ada6f.png)

