### PR TITLE
chore: remove blueberry from iso

### DIFF
--- a/community/sway/Packages-Desktop
+++ b/community/sway/Packages-Desktop
@@ -55,7 +55,6 @@ bluez-utils
 pulseaudio-alsa
 pulseaudio-ctl
 playerctl
-blueberry
 
 # Network
 avahi


### PR DESCRIPTION
relates to https://github.com/Manjaro-Sway/manjaro-sway/issues/204

merge only after blueberry-free desktop-settings release.