### PR TITLE
Update Packages-Desktop - Add qt6-wayland

### DIFF
--- a/community/sway/Packages-Desktop
+++ b/community/sway/Packages-Desktop
@@ -21,6 +21,7 @@ swaylock-effects # swaylock with nicer effects
 xorg-xwayland # xorg-wayland bridge
 >extra wlay # graphical display management like arandr
 qt5-wayland
+qt6-wayland
 gnome-keyring # unlock keyring on login
 polkit-gnome # polkit for visual superuser access
 >extra xdg-desktop-portal-wlr


### PR DESCRIPTION
`qt6-wayland` provides APIs for Wayland. It is required for `qbittorent` to work but is not listed as a dependency.