### PR TITLE
[feat] add qt6ct package

### DIFF
--- a/community/sway/Packages-Desktop
+++ b/community/sway/Packages-Desktop
@@ -39,6 +39,7 @@ firefox
 ## Themes
 
 qt5ct
+qt6ct
 kvantum-qt5
 kvantum-theme-matcha
 gtk3-nocsd


### PR DESCRIPTION
`qt6ct` is required to provide themes for qt6 applications such as qbittorent, strawberry etc same way `qt5ct` does for qt5 applications. I have created a separate pr for adding the config file.