### PR TITLE
fix: incompatible arguments when launching tuigreet

### DIFF
--- a/community/sway/desktop-overlay/etc/greetd/config.toml
+++ b/community/sway/desktop-overlay/etc/greetd/config.toml
@@ -2,5 +2,5 @@
 vt = "next"
 
 [default_session]
-command = "tuigreet --user-menu --user-menu-min-uid 1000 --remember --remember-session --remember-user-session --time --issue --asterisks"
+command = "tuigreet --user-menu --user-menu-min-uid 1000 --remember --remember-user-session --time --issue --asterisks"
 user = "greeter"


### PR DESCRIPTION
In `tuigreet`, the options `--remember-session` and `--remember-user-session` are mutually exclusive (see [here](https://github.com/apognu/tuigreet/blob/e40be84341f7bb7408cca78b55c0432bfe543c31/src/greeter.rs#L459)). In the currently distributed manjaro-sway image, this leads to the following error message that prevents the user from logging in after a fresh installation:

```
Only one of --remember-session and --remember-user-session may be used at the same time
```

This commit removes the `--remember-session` argument, assuming that for each user the sessions shall be remembered.

I'd be happy to see this one merged. Please let me know if I should create an issue somewhere first.