### PR TITLE
Added base-devel in Packages-Root

### DIFF
--- a/shared/Packages-Root
+++ b/shared/Packages-Root
@@ -6,6 +6,7 @@ acpi
 acpid
 amd-ucode
 b43-fwcutter
+base-devel
 btrfs-progs
 bzip2
 coreutils


### PR DESCRIPTION
As per #765, since we include yay in all profiles, it makes sense to add base-devel to be able to actually compile the packages.