### PR TITLE
chore(sway): drop manjaro-aur-support

### DIFF
--- a/community/sway/Packages-Desktop
+++ b/community/sway/Packages-Desktop
@@ -84,7 +84,6 @@ dhclient
 
 >extra yay
 >extra base-devel
->extra manjaro-aur-support
 pamac-gtk
 
 ## Utils


### PR DESCRIPTION
First of two, ordered so a broken build is not possible in between.

`community/sway/Packages-Desktop` requested `manjaro-aur-support`:

```
 >extra yay
 >extra base-devel
->extra manjaro-aur-support
 pamac-gtk
```

## Context

The package is upstream Manjaro's — authored by Stefano Capitani, from `gitlab.manjaro.org/packages/manjaro-aur-support` — but Manjaro no longer ships it:

```
manjaro core/extra/multilib (all 3 branches): absent
arch:                                          absent
manjaro-contrib (all 3 branches):              0.6-4
```

So `manjaro-contrib` is the only source and this image the only consumer. `iso_build.yaml` builds with `scope: full`, so `>extra` is stripped rather than dropped (`_extra="s|>extra||g"` in `manjaro-tools/lib/util.sh`) — the package really is requested on every sway build today.

## What it removes from the image

A pacman hook plus a `check-aur` autostart entry that warns when AUR packages are installed. `yay` and `base-devel` stay, so AUR use is unaffected — only the warning goes.

## Order matters

The package stays published in `manjaro-contrib` until this merges **and** a sway build comes back green. Retiring it first would break profile resolution exactly the way `lib32-libxvmc` currently does — the failure this branch's rebase just fixed.

Removal from the repository is prepared separately in [manjaro-contrib/packages#30](https://github.com/manjaro-contrib/packages/pull/30) and should not merge until then.

## Verified

No references remain anywhere in the profiles — `Packages-*` files and overlays both.